### PR TITLE
fix: copy syntax for multiple file copy

### DIFF
--- a/content/blogs/phantom-token/api/Dockerfile
+++ b/content/blogs/phantom-token/api/Dockerfile
@@ -1,10 +1,10 @@
 FROM oven/bun
 WORKDIR /app
 
-COPY package.json bun.lock .
+COPY package.json bun.lock ./
 RUN bun install --production
 
-COPY index.ts tsconfig.json .
+COPY index.ts tsconfig.json ./
 
 ENV NODE_ENV=production
 RUN bun build \


### PR DESCRIPTION
Without the `/`, Docker would misinterpret the destination as a file and fail when handling multiple sources.