### PR TITLE
add hurl test

### DIFF
--- a/content/blogs/phantom-token/shell.nix
+++ b/content/blogs/phantom-token/shell.nix
@@ -3,5 +3,6 @@ pkgs.mkShell {
   packages = with pkgs; [
     bun
     go
+    hurl
   ];
 }

--- a/content/blogs/phantom-token/test.hurl
+++ b/content/blogs/phantom-token/test.hurl
@@ -1,0 +1,12 @@
+POST http://localhost:7891/auth/user
+{ "name": "pina" }
+HTTP 201
+[Captures]
+session_token: jsonpath "$['token']"
+
+GET http://localhost:7891/api/me
+authorization: Bearer {{session_token}}
+HTTP 200
+[Asserts]
+jsonpath "$['sub']" == "pina"
+jsonpath "$['iss']" == "keibi-blog"


### PR DESCRIPTION
This writes the api tests via hurl.  hurl is a minimalist api testing tool and heavily leverages curl under the hood.  

Opened an issue with hurl for assistance on writing the other assertions about issued at and expiration.  https://github.com/Orange-OpenSource/hurl/issues/3929